### PR TITLE
first commit of example recording conversion using toy data

### DIFF
--- a/example_recording/examplenwbconverter.py
+++ b/example_recording/examplenwbconverter.py
@@ -1,0 +1,14 @@
+"""Authors: Cody Baker and Ben Dichter."""
+from nwb_conversion_tools import NWBConverter
+from examplerecordinginterface import ExampleRecordingInterface
+
+
+class ExampleNWBConverter(NWBConverter):
+    """Primary conversion class for the GrosmarkAD dataset."""
+
+    data_interface_classes = dict(
+        ExampleRecording=ExampleRecordingInterface,
+        # TODO: add below
+        # ExampleSorting=neuroscopedatainterface.NeuroscopeSortingInterface,
+        # ExampleLFP=NeuroscopeLFPInterface
+    )

--- a/example_recording/examplerecordinginterface.py
+++ b/example_recording/examplerecordinginterface.py
@@ -1,0 +1,57 @@
+"""Authors: Cody Baker and Ben Dichter."""
+import spikeextractors as se
+import numpy as np
+
+from nwb_conversion_tools.baserecordingextractorinterface import BaseRecordingExtractorInterface
+
+
+class ExampleRecordingInterface(BaseRecordingExtractorInterface):
+    """An example RecordingInterface class."""
+
+    RX = se.NumpyRecordingExtractor
+
+    def __init__(self, **input_args):
+        self.recording_extractor = se.example_datasets.toy_example()[0]  # self.RX(**input_args)
+
+    def get_metadata(self):
+        """Return as much auto-populated metadata as possible."""
+        re_metadata = dict(
+            Ecephys=dict(
+                # This specifies a subset of the channels from the recording
+                subset_channels=list(range(self.recording_extractor.get_num_channels())),
+                Device=[
+                    dict(
+                        description="Description of the device."
+                    )
+                ],
+                ElectrodeGroup=[
+                    dict(
+                        name=f'NameOfElectrodeGroup{n+1}',
+                        description=f"Description of electrodes on ElectrodeGroup{n+1}."
+                    )
+                    for n, _ in enumerate(np.unique(self.recording_extractor.get_channel_groups()))
+                ],
+                Electrodes=[
+                    dict(
+                        name='CustomElectrodeColumn',
+                        description="Description of optional electrode column.",
+                        data=list(range(self.recording_extractor.get_num_channels()))
+                    ),
+                    dict(
+                        name='group',
+                        description="A reference to the ElectrodeGroup this electrode is a part of.",
+                        data=list(self.recording_extractor.get_channel_groups())
+                    ),
+                    dict(
+                        name='group_name',
+                        description="The name of the ElectrodeGroup this electrode is a part of.",
+                        data=[f"NameOfElectrodeGroup{n+1}" for n in self.recording_extractor.get_channel_groups()]
+                    )
+                ],
+                ElectricalSeries=dict(
+                    name='ElectricalSeries',
+                    description="raw acquisition traces"
+                )
+            )
+        )
+        return re_metadata

--- a/example_recording/run_converter_recording.py
+++ b/example_recording/run_converter_recording.py
@@ -1,0 +1,48 @@
+"""Authors: Cody Baker."""
+from examplenwbconverter import ExampleNWBConverter
+from pathlib import Path
+
+# General location information for the session
+example_path = Path("D:/ExampleNWBConversion")
+example_session_id = example_path.stem
+nwbfile_path = example_path / f"{example_session_id}.nwb"
+
+device_description = "Optional description of the recording device."
+
+# There is one input argument key per data interface, each corresponding to the parts of the data we want to convert
+input_args = dict(
+    ExampleRecording=dict(),
+    # TODO: add below
+    # ExampleSorting=dict(
+    #     folder_path=example_path
+    # ),
+    # ExampleLFP=dict(
+    #     folder_path=example_path
+    # ),
+)
+
+example_converter = ExampleNWBConverter(**input_args)
+
+# Auto-populates as much metadata as possible
+metadata = example_converter.get_metadata()
+
+# Add specific info for this session
+metadata['NWBFile'] = dict(
+    experimenter="Experimenter Name",
+    session_description="This describes the experiment used to make the dataset."
+)
+metadata['Ecephys']['Device'][0].update(
+    description="Optional description of the recording device."
+)
+
+# All of these subject fields are optional but recommended, if known
+metadata['Subject'] = dict(
+    species="Rattus norvegicus domestica",  # this should always be the scientific name for the species
+    genotype="Wild type",
+    sex="male",
+    weight="250-350g"
+)
+
+# Run the conversion; for a large dataset, consider passing the "stub_test=True"
+# option to ensure the output NWBFile looks OK
+example_converter.run_conversion(nwbfile_path=str(nwbfile_path.absolute()), metadata_dict=metadata)


### PR DESCRIPTION
@bendichter @luiztauffer @alejoe91 Here are three example files showing the design and use of 

1. A primary conversion script using an NWBConverter object
2. A custom NWBConverter class specifying our data interface classes (and potentially more, if we want to do anything more customized)
3. A custom recording interface inheriting from the BaseRecordingExtractorInterface

Let's discuss this design (which is in line with [nwb-conversion-tools branch "refactor_interface_metadata"](https://github.com/catalystneuro/nwb-conversion-tools/tree/refactor_interface_metadata), but not the ["schema_compliance" ](https://github.com/catalystneuro/nwb-conversion-tools/tree/schema_compliance) just yet), as well as the folder structure for these codes. I tend to include all three in the same folder, whereas I noticed @luiztauffer separates the script from the converter class.

Note this branch doesn't include the setup or nicely written schemas that are on @luiztauffer's branch, just the core codes.